### PR TITLE
Hiding health services from metadata page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/55830emag9ksyasf/branch/master?svg=true)](https://ci.appveyor.com/project/wwwlicious/servicestack-discovery-consul)
 [![NuGet version](https://badge.fury.io/nu/ServiceStack.Discovery.Consul.svg)](https://badge.fury.io/nu/ServiceStack.Discovery.Consul)
 
-A plugin for [ServiceStack](https://servicestack.net/) that provides transparent service discovery using [Consul.io](http://consul.io) with automatic service registration and health checking.
+A plugin for [ServiceStack](https://servicestack.net/) that provides 
+transparent [client service discovery](http://microservices.io/patterns/client-side-discovery.html) 
+using [Consul.io](http://consul.io) as a [Service Registry](http://microservices.io/patterns/service-registry.html)
 
-This enables your servicestack instances to call one another, without either knowing where the other is, based solely on a copy of the requestDTO. Your services will not need to take any dependencies on each other and as you deploy updates to your services they will automatically be registered and used without reconfiguing the existing services.
+This enables distributed servicestack instances to call one another, 
+without either knowing where the other is, based solely on a 
+copy of the .Net CLR request type. 
 
-The customisable health checks for each service will also ensure that failing services will not be used, or if you run multiple instances of a service, only the healthy and most responsive service will be returned. 
+Your services will not need to take **any dependencies** on each other 
+and as you deploy updates to your services they will **automatically be registered** 
+and used without reconfiguing the existing services.
+
+The automatic and customisable health checks for each service will 
+also ensure that **failing services will not be used**, or if you 
+run multiple instances of a service, only the healthy and **most responsive** 
+service will be returned. 
 
 ![RequestDTO Service Discovery](assets/RequestDTOServiceDiscovery.png)
 
@@ -72,10 +83,11 @@ You should now be able see the [Consul Agent WebUI](http://127.0.0.1:8500/ui) li
 
 ![Automatic Service Registration](assets/ServiceRegistration.png)
 
-Once you have added the plugin to your ServiceStack AppHost and started it up, it will set up the following:
+Once you have added the plugin to your ServiceStack AppHost and 
+started it up, it will [self-register](http://microservices.io/patterns/self-registration.html):
 
-* Registers the service and it's requestDTO's with Consul for other services to be able to find.
-* Deregisters the service when the AppHost is shutdown so that other services get only active services.
+* AppHost.AfterInit - Registers the service and it's operations in the service registry.
+* AppHost.OnDispose - Deregisters the service when the AppHost is shutdown.
 
 ### Health checks
 
@@ -98,7 +110,7 @@ new ConsulFeature(settings => { settings.IncludeDefaultServiceHealth = false; })
 
 You can add your own health checks in one of two ways
 
-##### 1. Setting the `ConsulFeature.ServiceHealthCheck` property. 
+#### 1. Define your own health check delegate. 
 
 ```csharp
 new ConsulFeature(settings =>
@@ -121,7 +133,7 @@ new ConsulFeature(settings =>
 _If an exception is thrown from this
 check, the healthcheck will return **Critical** to consul along with the exception_
 
-##### 2. Specifying HTTP or TCP endpoints
+#### 2. Specifying HTTP or TCP endpoints
 
 ```csharp
 new ConsulFeature(settings =>
@@ -171,7 +183,7 @@ public class CustomDiscoveryRequestTypeResolver : IDiscoveryRequestTypeResolver
 }
 ```
 
-#### Configuring the external Gateway
+### Configuring the external Gateway
 
 To change the default external `IServiceGateway` used, or just to add additional configuration, 
 you can set the following setting: 

--- a/src/Servicestack.Discovery.Consul/Checks/HealthCheckService.cs
+++ b/src/Servicestack.Discovery.Consul/Checks/HealthCheckService.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.Discovery.Consul
     /// This service creates health endpoints for consul to issue requests to
     /// </summary>
     /// <remarks>The heartbeat is executed when this service is registered to obtain the baseUrl</remarks>
-    [Exclude(Feature.Metadata)]
+    [Restrict(VisibilityTo = RequestAttributes.None)]
     public class HealthCheckService : Service
     {
         /// <summary>

--- a/src/Servicestack.Discovery.Consul/Consul.cs
+++ b/src/Servicestack.Discovery.Consul/Consul.cs
@@ -1,7 +1,6 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 namespace ServiceStack.Discovery.Consul
 {
     public static class Consul

--- a/src/Servicestack.Discovery.Consul/Consul/ConsulCatalogServiceResponse.cs
+++ b/src/Servicestack.Discovery.Consul/Consul/ConsulCatalogServiceResponse.cs
@@ -1,21 +1,15 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// file, You can obtain one at http://mozilla.org/MPL/2.0/. 
 namespace ServiceStack.Discovery.Consul
 {
     /// <summary>
-    /// Represents a consul registered service address
+    /// Represents a consul registered service and it's tags 
     /// </summary>
-    public class ConsulServiceResponse
+    public class ConsulCatalogServiceResponse
     {
         public string ID { get; set; }
 
-        public string Service { get; set; }
-
         public string[] Tags { get; set; }
-
-        public string Address { get; set; }
-
-        public int Port { get; set; } = 0;
     }
 }

--- a/src/Servicestack.Discovery.Consul/Consul/ConsulRegisterCheck.cs
+++ b/src/Servicestack.Discovery.Consul/Consul/ConsulRegisterCheck.cs
@@ -5,13 +5,16 @@ namespace ServiceStack.Discovery.Consul
 {
     using System.Runtime.Serialization;
 
+    /// <summary>
+    /// Represents a consul health check
+    /// </summary>
     [Route("/v1/agent/check/register", "PUT")]
     public class ConsulRegisterCheck : IUrlFilter
     {
         /// <summary>
         /// Creates a new health check in consul
         /// </summary>
-        /// <param name="name">The name to use for the health check in consul - descriptive only</param>
+        /// <param name="name">The name to use for the health check in consul</param>
         /// <param name="serviceId">The Id of service to associate this health check with</param>
         public ConsulRegisterCheck(string name, string serviceId = null)
         {
@@ -48,12 +51,24 @@ namespace ServiceStack.Discovery.Consul
 
         public string DockerContainerID { get; set; }
 
+        /// <summary>
+        /// Reference a shell script relative to the consul agent path
+        /// </summary>
         public string Shell { get; set; }
 
+        /// <summary>
+        /// the GET HTTP URL consul will query
+        /// </summary>
         public string HTTP { get; set; }
 
+        /// <summary>
+        /// the TCP IP:PORT address consul will query
+        /// </summary>
         public string TCP { get; set; }
 
+        /// <summary>
+        /// the frequency with which consul will run the health check
+        /// </summary>
         [IgnoreDataMember]
         public double? IntervalInSeconds { get; set; }
 

--- a/src/Servicestack.Discovery.Consul/Consul/ConsulUris.cs
+++ b/src/Servicestack.Discovery.Consul/Consul/ConsulUris.cs
@@ -11,6 +11,10 @@ namespace ServiceStack.Discovery.Consul
 
         public static readonly Func<string, string> DeregisterService = serviceId => $"{LocalAgent}/v1/agent/service/deregister/{serviceId}";
 
-        public static readonly string GetServices = $"{LocalAgent}/v1/agent/services";
+        /// <summary>
+        /// Uri for retrieving a list of services 
+        /// </summary>
+        /// <remarks><see cref="https://www.consul.io/docs/agent/http/catalog.html#catalog_services"/></remarks>
+        public static readonly string GetServices = $"{LocalAgent}/v1/catalog/services?near=_agent";
     }
 }

--- a/src/Servicestack.Discovery.Consul/ConsulFeatureSettings.cs
+++ b/src/Servicestack.Discovery.Consul/ConsulFeatureSettings.cs
@@ -11,6 +11,9 @@ namespace ServiceStack.Discovery.Consul
 
     public class ConsulFeatureSettings
     {
+        /// <summary>
+        /// Prefix used when registering and looking up requestDTO's
+        /// </summary>
         public const string TagDtoPrefix = "req-";
 
         private readonly List<string> customTags = new List<string>();
@@ -23,10 +26,13 @@ namespace ServiceStack.Discovery.Consul
 
         private DefaultGatewayDelegate defaultGateway = baseUri => new JsonServiceClient(baseUri);
 
+        /// <summary>
+        /// Set to false to exclude adding the default health checks on service registration
+        /// </summary>
         public bool IncludeDefaultServiceHealth { get; set; } = true;
         
         /// <summary>
-        /// Add service tags
+        /// Add custom service tags to your service registration
         /// </summary>
         /// <param name="tags"></param>
         public void AddTags(params string[] tags)
@@ -83,26 +89,46 @@ namespace ServiceStack.Discovery.Consul
             defaultGateway = externalGateway;
         }
 
+        /// <summary>
+        /// Get's the preferred external gateway for service discovery
+        /// </summary>
+        /// <returns></returns>
         public DefaultGatewayDelegate GetGateway()
         {
             return defaultGateway;
         }
 
+        /// <summary>
+        /// Gets the list of custom tags registered with the service
+        /// </summary>
+        /// <returns></returns>
         public string[] GetCustomTags()
         {
             return customTags.ToArray();
         }
 
+        /// <summary>
+        /// Gets the custom health check delegate for the service registration
+        /// </summary>
+        /// <returns></returns>
         public HostHealthCheck GetHealthCheck()
         {
             return healthCheck;
         }
 
+        /// <summary>
+        /// Gets the custom service checks for the service registration
+        /// </summary>
+        /// <returns></returns>
         public ConsulRegisterCheck[] GetServiceChecks()
         {
             return serviceChecks.ToArray();
         }
 
+        /// <summary>
+        /// Gets the type resolver used for service discovery
+        /// </summary>
+        /// <returns></returns>
         public IDiscoveryRequestTypeResolver GetDiscoveryTypeResolver()
         {
             return typeResolver;

--- a/src/Servicestack.Discovery.Consul/Discovery/GatewayServiceDiscoveryException.cs
+++ b/src/Servicestack.Discovery.Consul/Discovery/GatewayServiceDiscoveryException.cs
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+namespace ServiceStack.Discovery.Consul
+{
+    using System;
+
+    public class GatewayServiceDiscoveryException : WebServiceException
+    {
+        public GatewayServiceDiscoveryException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public GatewayServiceDiscoveryException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Servicestack.Discovery.Consul/Discovery/IDiscoveryRequestTypeResolver.cs
+++ b/src/Servicestack.Discovery.Consul/Discovery/IDiscoveryRequestTypeResolver.cs
@@ -7,10 +7,26 @@ namespace ServiceStack.Discovery.Consul
 
     public interface IDiscoveryRequestTypeResolver
     {
+        /// <summary>
+        /// Inspects the IAppHost and returns a list of strings that will represent the RequestDTO types
+        /// These strings are used by <see cref="ResolveBaseUri(object)"/> to find the AppHost's BaseUri
+        /// </summary>
+        /// <param name="host"></param>
+        /// <returns></returns>
         string[] GetRequestTypes(IAppHost host);
 
+        /// <summary>
+        /// Takes a dto object and returns the correct BaserUri for the gateway to send it to
+        /// </summary>
+        /// <param name="dto">the request dto</param>
+        /// <returns>the BaseUri that will serve this request</returns>
         string ResolveBaseUri(object dto);
 
+        /// <summary>
+        /// Takes a dto type and returns the correct BaseUri for the gateway to send it to
+        /// </summary>
+        /// <param name="dtoType">The request dto type</param>
+        /// <returns>the BaserUri that will serve this request</returns>
         string ResolveBaseUri(Type dtoType);
     }
 }

--- a/src/Servicestack.Discovery.Consul/ServiceStack.Discovery.Consul.csproj
+++ b/src/Servicestack.Discovery.Consul/ServiceStack.Discovery.Consul.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ConsulFeature.cs" />
     <Compile Include="ConsulFeatureSettings.cs" />
     <Compile Include="ConsulServiceGatewayFactory.cs" />
+    <Compile Include="Consul\ConsulCatalogServiceResponse.cs" />
     <Compile Include="Consul\ConsulRegisterCheck.cs" />
     <Compile Include="Consul\ConsulRegisterCheckValidator.cs" />
     <Compile Include="Consul\ConsulRegisterServiceValidator.cs" />
@@ -87,6 +88,7 @@
     <Compile Include="Consul\ConsulServiceResponse.cs" />
     <Compile Include="Consul\ConsulUris.cs" />
     <Compile Include="Discovery\DefaultDiscoveryRequestTypeResolver.cs" />
+    <Compile Include="Discovery\GatewayServiceDiscoveryException.cs" />
     <Compile Include="Discovery\IDiscoveryRequestTypeResolver.cs" />
     <Compile Include="HostHealthCheck.cs" />
     <Compile Include="InvalidTagException.cs" />

--- a/test/ServiceStack.Discovery.Consul.Tests/ConsulClientTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/ConsulClientTests.cs
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/. 
 namespace ServiceStack.Discovery.Consul.Tests
 {
+    using System;
+    using FluentAssertions;
     using Xunit;
 
     [Collection("AppHost")]
@@ -13,6 +15,138 @@ namespace ServiceStack.Discovery.Consul.Tests
         public ConsulClientTests(AppHostFixture fixture)
         {
             this.fixture = fixture;
+        }
+
+        [Fact]
+        public void GetServices_ParsesExpectedJsonCorrectly()
+        {
+            using (new HttpResultsFilter(@"{""SS-S1"":[""req-one"", ""ServiceStack""],""SS-S2"":[""req-two"", ""ServiceStack""],}"))
+            {
+                var services = ConsulClient.GetServices();
+
+                services.Should()
+                    .HaveCount(2)
+                    .And.ContainSingle(x => x.ID == "SS-S1")
+                    .And.ContainSingle(x => x.ID == "SS-S2");
+            }
+        }
+
+        [Fact]
+        public void CanFilterServicesByTag()
+        {
+            using (new HttpResultsFilter(@"{""SS-S1"":[""req-one"", ""ServiceStack""],""SS-S2"":[""req-two"", ""ServiceStack""],}"))
+            {
+                var services = ConsulClient.FindService("two");
+                services.Should().HaveCount(1).And.ContainSingle(x => x.ID == "SS-S2");
+            }
+        }
+
+        [Fact]
+        public void FindService_ReturnsEmpty_WhenNoIsTagMatch()
+        {
+            using (new HttpResultsFilter(@"{""SS-S1"":[""req-one"", ""ServiceStack""],""SS-S2"":[""req-two"", ""ServiceStack""],}"))
+            {
+                var services = ConsulClient.FindService("three");
+
+                services.Should().BeEmpty();
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void FindService_ThrowsException_WhenResponseIsEmpty(string response)
+        {
+            using (new HttpResultsFilter(response))
+            {
+                Action action = () => ConsulClient.FindService("three");
+
+                var ex = action.ShouldThrow<GatewayServiceDiscoveryException>();
+                ex.WithMessage("Unable to retrieve services from Consul");
+                ex.WithInnerException<WebServiceException>()
+                    .WithInnerMessage("Expected json but received empty or null reponse from http://127.0.0.1:8500/v1/catalog/services?near=_agent");
+            }
+        }
+
+        [Fact]
+        public void GetServices_ThrowsException_IfRequestThrowsException()
+        {
+            using (new HttpResultsFilter { StringResultFn = (request, s) => { throw new Exception("unexpected"); }})
+            {
+                Action action = () => ConsulClient.GetServices();
+
+                var ex = action.ShouldThrow<GatewayServiceDiscoveryException>();
+                ex.WithMessage("Unable to retrieve services from Consul");
+                ex.WithInnerException<Exception>().WithInnerMessage("unexpected");
+            }
+        }
+
+        [Fact]
+        public void GetService_WithNoMatchingTag_ThrowException()
+        {
+            using (new HttpResultsFilter(@"{""SS-S1"":[""req-one"", ""ServiceStack""],""SS-S2"":[""req-two"", ""ServiceStack""],}"))
+            {
+                Action action = () => ConsulClient.GetService("three");
+
+                action.ShouldThrow<GatewayServiceDiscoveryException>().WithMessage("No services are currently registered to process the request of type 'three'");
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void GetService_ThrowsException_WhenServiceRequestResponseIsEmpty(string response)
+        {
+            using (new HttpResultsFilter
+            {
+                StringResultFn = (request, s) =>
+                {
+                    if (request.RequestUri.AbsoluteUri == "http://127.0.0.1:8500/v1/catalog/services?near=_agent")
+                    {
+                        return @"{""SS-S1"":[""req-one"", ""ServiceStack""],""SS-S2"":[""req-two"", ""ServiceStack""],}";
+                    }
+                    return response;
+                }
+            })
+            {
+                Action action = () => ConsulClient.GetService("one");
+                action.ShouldThrow<GatewayServiceDiscoveryException>()
+                    .WithMessage("No healthy services are currently registered to process the request of type 'one'")
+                    .WithInnerException<WebServiceException>()
+                    .WithInnerMessage("Expected json but received empty or null reponse from http://127.0.0.1:8500/v1/health/service/SS-S1?near=_agent&passing=true&tag=req-one");
+            }
+        }
+
+        [Fact]
+        public void GetService_ReturnsCorrectly_WhenHealthyService()
+        {
+            using (new HttpResultsFilter
+            {
+                StringResultFn = (request, s) =>
+                {
+                    if (request.RequestUri.AbsoluteUri == "http://127.0.0.1:8500/v1/catalog/services?near=_agent")
+                    {
+                        return @"{""SS-S1"":[""req-EchoA"", ""ServiceStack""],""SS-S2"":[""req-two"", ""ServiceStack""],}";
+                    }
+                    if (request.RequestUri.AbsoluteUri == "http://127.0.0.1:8500/v1/health/service/SS-S1?near=_agent&passing=true&tag=req-EchoA")
+                    {
+                        return
+                            @"[{""Node"":{""Node"":""X1-Win10"",""Address"":""127.0.0.1"",""TaggedAddresses"":{""wan"":""127.0.0.1""},""CreateIndex"":3,""ModifyIndex"":1612},""Service"":{""ID"":""SS-ServiceAv2-0"",""Service"":""SS-ServiceA"",""Tags"":[""v2-0"",""ServiceStack"",""req-EchoA"",""one"",""two"",""three""],""Address"":""http://127.0.0.1:8091/"",""Port"":0,""EnableTagOverride"":false,""CreateIndex"":1607,""ModifyIndex"":1612},""Checks"":[{""Node"":""X1-Win10"",""CheckID"":""serfHealth"",""Name"":""Serf Health Status"",""Status"":""passing"",""Notes"":"""",""Output"":""Agent alive and reachable"",""ServiceID"":"""",""ServiceName"":"""",""CreateIndex"":3,""ModifyIndex"":3},{""Node"":""X1-Win10"",""CheckID"":""SS-ServiceAv2-0:SS-HealthCheck"",""Name"":""SS-HealthCheck"",""Status"":""passing"",""Notes"":""This check is an HTTP GET request which expects the service to return 200 OK"",""Output"":"""",""ServiceID"":""SS-ServiceAv2-0"",""ServiceName"":""SS-ServiceA"",""CreateIndex"":1609,""ModifyIndex"":1612},{""Node"":""X1-Win10"",""CheckID"":""SS-ServiceAv2-0:SS-HeartBeat"",""Name"":""SS-HeartBeat"",""Status"":""passing"",""Notes"":""A heartbeat service to check if the service is reachable, expects 200 response"",""Output"":"""",""ServiceID"":""SS-ServiceAv2-0"",""ServiceName"":""SS-ServiceA"",""CreateIndex"":1608,""ModifyIndex"":1611}]}]";
+                    }
+                    return null;
+                }
+            })
+            {
+                var response = ConsulClient.GetService("EchoA");
+
+                response.Service.Should().Be("SS-ServiceA");
+                response.ID.Should().Be("SS-ServiceAv2-0");
+                response.Address.Should().Be("http://127.0.0.1:8091/");
+                response.Port.Should().Be(0);
+                response.Tags.Should().BeEquivalentTo("v2-0", "ServiceStack", "req-EchoA", "one", "two", "three");
+            }
         }
     }
 }

--- a/test/ServiceStack.Discovery.Consul.Tests/ConsulUrisTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/ConsulUrisTests.cs
@@ -12,7 +12,7 @@ namespace ServiceStack.Discovery.Consul.Tests
         [Fact]
         public void GetServicesUri_IsCorrect()
         {
-            ConsulUris.GetServices.Should().Be("http://127.0.0.1:8500/v1/agent/services");
+            ConsulUris.GetServices.Should().Be("http://127.0.0.1:8500/v1/catalog/services?near=_agent");
         }
 
         [Fact]

--- a/test/ServiceStack.Discovery.Consul.Tests/GatewayServiceDiscoveryExceptionpeResolverTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/GatewayServiceDiscoveryExceptionpeResolverTests.cs
@@ -7,11 +7,11 @@ using Xunit;
 namespace ServiceStack.Discovery.Consul.Tests
 {
     [Collection("AppHost")]
-    public class DefaultDiscoveryRequestTypeResolverTests
+    public class GatewayServiceDiscoveryExceptionpeResolverTests
     {
         private readonly AppHostFixture fixture;
 
-        public DefaultDiscoveryRequestTypeResolverTests(AppHostFixture fixture)
+        public GatewayServiceDiscoveryExceptionpeResolverTests(AppHostFixture fixture)
         {
             this.fixture = fixture;
         }

--- a/test/ServiceStack.Discovery.Consul.Tests/HealthCheckServiceTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/HealthCheckServiceTests.cs
@@ -48,7 +48,7 @@ namespace ServiceStack.Discovery.Consul.Tests
             res.Should().BeOfType<Heartbeat>().Which.Url.Should().Be("http://localhost");
         }
 
-        [Fact(Skip = "Working locally, failing on appveyor, needs investigation")]
+        [Fact]
         public void HealthCheck_Should_Return_200()
         {
             var req = new HealthCheck();

--- a/test/ServiceStack.Discovery.Consul.Tests/ServiceStack.Discovery.Consul.Tests.csproj
+++ b/test/ServiceStack.Discovery.Consul.Tests/ServiceStack.Discovery.Consul.Tests.csproj
@@ -86,7 +86,7 @@
   <ItemGroup>
     <Compile Include="ConsulFeatureSettingsTests.cs" />
     <Compile Include="ConsulUrisTests.cs" />
-    <Compile Include="DefaultDiscoveryRequestTypeResolverTests.cs" />
+    <Compile Include="GatewayServiceDiscoveryExceptionpeResolverTests.cs" />
     <Compile Include="Helpers\AppHostCollection.cs" />
     <Compile Include="ConsulClientTests.cs" />
     <Compile Include="Helpers\AppHostFixture.cs" />

--- a/test/TestServiceA/Program.cs
+++ b/test/TestServiceA/Program.cs
@@ -55,8 +55,6 @@ namespace TestServiceA
                 settings.AddTags("one", "two", "three");
                 settings.SetDefaultGateway(url => new CsvServiceClient(url));
             }));
-
-            Plugins.Add(new MetadataFeature());
         }
     }
 


### PR DESCRIPTION
Moving service location logic from DefaultDiscoveryRequestTypeResolver to the ConsulClient
Adding GatewayServiceDiscoveryException for all consul lookup exceptions
Adding prefix to service and tag and healthcheck registration
Adding service lookups by tag
Adding service sorting by round trip times
Adding service filtering by passing health
Adding public member docs
Adding tests
Few readme updates