### PR TITLE
Adding service deregistration timeout on critical health checks from Consul >= 0.7 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ copy of the .Net CLR request type.
 
 Your services will not need to take **any dependencies** on each other 
 and as you deploy updates to your services they will **automatically be registered** 
-and used without reconfiguing the existing services.
+and used without reconfiguring the existing services.
 
 The automatic and customisable health checks for each service will 
 also ensure that **failing services will not be used**, or if you 
@@ -103,12 +103,15 @@ started it up, it will [self-register](http://microservices.io/patterns/self-reg
 
 ![Default Health Checks](assets/HealthChecks.png)
 
-Each service can have any number of health checks. These checks are run by Consul and allow service discovery to filter out failing instances of your services.
+Each service can have any number of health checks. These checks are run by Consul and allow service discovery 
+to filter out failing instances of your services.
 
 By default the plugin creates 2 health checks
 
 1. Heartbeat : Creates an endpoint in your service [http://locahost:1234/reply/json/heartbeat](http://locahost:1234/reply/json/heartbeat) that expects a 200 response
 2. If Redis has been configured in the AppHost, it will check Redis is responding
+
+*NB From Consul 0.7 onwards, if the heartbeat check fails for 90 minutes, the service will automatically be unregistered*
 
 You can turn off the default health checks by setting the following property:
 
@@ -136,7 +139,8 @@ new ConsulFeature(settings =>
         ...ok check 
         return new HealthCheck(ServiceHealth.Ok, "working normally");
     },
-    intervalInSeconds: 60 // default check once per minute
+    intervalInSeconds: 60 // default check once per minute,
+    deregisterIfCriticalAfterInMinutes: null // deregisters the service if health is critical after x minutes, null = disabled by default
     );
 });
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ copy of the .Net CLR request type.
 
 Your services will not need to take **any dependencies** on each other 
 and as you deploy updates to your services they will **automatically be registered** 
-and used without reconfiguing the existing services.
+and used without reconfiguring the existing services.
 
 The automatic and customisable health checks for each service will 
 also ensure that **failing services will not be used**, or if you 
@@ -93,12 +93,15 @@ started it up, it will [self-register](http://microservices.io/patterns/self-reg
 
 ![Default Health Checks](assets/HealthChecks.png)
 
-Each service can have any number of health checks. These checks are run by Consul and allow service discovery to filter out failing instances of your services.
+Each service can have any number of health checks. These checks are run by Consul and allow service discovery 
+to filter out failing instances of your services.
 
 By default the plugin creates 2 health checks
 
 1. Heartbeat : Creates an endpoint in your service [http://locahost:1234/reply/json/heartbeat](http://locahost:1234/reply/json/heartbeat) that expects a 200 response
 2. If Redis has been configured in the AppHost, it will check Redis is responding
+
+*NB From Consul 0.7 onwards, if the heartbeat check fails for 90 minutes, the service will automatically be unregistered*
 
 You can turn off the default health checks by setting the following property:
 
@@ -126,7 +129,8 @@ new ConsulFeature(settings =>
         ...ok check 
         return new HealthCheck(ServiceHealth.Ok, "working normally");
     },
-    intervalInSeconds: 60 // default check once per minute
+    intervalInSeconds: 60 // default check once per minute,
+    deregisterIfCriticalAfterInMinutes: null // deregisters the service if health is critical after x minutes, null = disabled by default
     );
 });
 ```

--- a/src/ServiceStack.Discovery.Consul.sln
+++ b/src/ServiceStack.Discovery.Consul.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1B7F3199-DD93-4058-841F-9C26AD11B185}"
 EndProject

--- a/src/ServiceStack.Discovery.Consul.sln
+++ b/src/ServiceStack.Discovery.Consul.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1B7F3199-DD93-4058-841F-9C26AD11B185}"
 EndProject

--- a/src/Servicestack.Discovery.Consul/Consul/ConsulClient.cs
+++ b/src/Servicestack.Discovery.Consul/Consul/ConsulClient.cs
@@ -154,6 +154,7 @@ namespace ServiceStack.Discovery.Consul
                         TCP = check.Tcp,
                         IntervalInSeconds = check.IntervalInSeconds,
                         Notes = check.Notes,
+                        
                     };
                     HealthcheckValidator.ValidateAndThrow(consulCheck);
 

--- a/src/Servicestack.Discovery.Consul/Consul/ConsulClient.cs
+++ b/src/Servicestack.Discovery.Consul/Consul/ConsulClient.cs
@@ -154,7 +154,7 @@ namespace ServiceStack.Discovery.Consul
                         TCP = check.Tcp,
                         IntervalInSeconds = check.IntervalInSeconds,
                         Notes = check.Notes,
-                        
+                        DeregisterCriticalServiceAfterInMinutes = check.DeregisterCriticalServiceAfterInMinutes
                     };
                     HealthcheckValidator.ValidateAndThrow(consulCheck);
 

--- a/src/Servicestack.Discovery.Consul/Consul/ConsulRegisterCheck.cs
+++ b/src/Servicestack.Discovery.Consul/Consul/ConsulRegisterCheck.cs
@@ -74,6 +74,14 @@ namespace ServiceStack.Discovery.Consul
 
         public string Interval => IntervalInSeconds?.ToString("0s");
 
+        /// <summary>
+        /// Deregisters a service with critical health after x minutes
+        /// </summary>
+        [IgnoreDataMember]
+        public double? DeregisterCriticalServiceAfterInMinutes { get; set; }
+
+        public string DeregisterCriticalServiceAfter => DeregisterCriticalServiceAfterInMinutes?.ToString("0m");
+
         [IgnoreDataMember]
         public string AclToken { get; set; }
 

--- a/src/Servicestack.Discovery.Consul/ConsulFeatureSettings.cs
+++ b/src/Servicestack.Discovery.Consul/ConsulFeatureSettings.cs
@@ -61,9 +61,10 @@ namespace ServiceStack.Discovery.Consul
         /// </summary>
         /// <param name="check">a delegate to represent a service health check</param>
         /// <param name="intervalInSeconds">the timed interval for running this check in seconds</param>
-        public void AddServiceCheck(HealthCheckDelegate check, int intervalInSeconds = 60)
+        /// <param name="deregisterIfCriticalAfterInMinutes">Instructs consul to deregister the service if the service check is failing after x minutes</param>
+        public void AddServiceCheck(HealthCheckDelegate check, int intervalInSeconds = 60, int? deregisterIfCriticalAfterInMinutes = null)
         {
-            healthCheck = new HostHealthCheck(check, intervalInSeconds);
+            healthCheck = new HostHealthCheck(check, intervalInSeconds, deregisterIfCriticalAfterInMinutes);
         }
 
         /// <summary>

--- a/src/Servicestack.Discovery.Consul/Discovery/ConsulDiscovery.cs
+++ b/src/Servicestack.Discovery.Consul/Discovery/ConsulDiscovery.cs
@@ -167,7 +167,7 @@ namespace ServiceStack.Discovery.Consul
                 Id = "SS-HealthCheck",
                 ServiceId = serviceId,
                 IntervalInSeconds = customHealthCheck.IntervalInSeconds,
-                DeregisterCriticalServiceAfterInSeconds = customHealthCheck.DeregisterIfCriticalAfterInMinutes,
+                DeregisterCriticalServiceAfterInMinutes = customHealthCheck.DeregisterIfCriticalAfterInMinutes,
                 Http = baseUrl.CombineWith("/json/reply/healthcheck"),
                 Notes = "This check is an HTTP GET request which expects the service to return 200 OK"
             };
@@ -219,7 +219,7 @@ namespace ServiceStack.Discovery.Consul
                 IntervalInSeconds = 30,
                 Http = baseUrl.CombineWith("/json/reply/heartbeat"),
                 Notes = "A heartbeat service to check if the service is reachable, expects 200 response",
-                DeregisterCriticalServiceAfterInSeconds = 90
+                DeregisterCriticalServiceAfterInMinutes = 90
             };
         }
     }

--- a/src/Servicestack.Discovery.Consul/Discovery/ConsulDiscovery.cs
+++ b/src/Servicestack.Discovery.Consul/Discovery/ConsulDiscovery.cs
@@ -156,7 +156,8 @@ namespace ServiceStack.Discovery.Consul
         private ServiceHealthCheck CreateCustomCheck(string baseUrl, string serviceId)
         {
             var settings = HostContext.GetPlugin<ConsulFeature>().Settings;
-            if (settings.GetHealthCheck() == null)
+            var customHealthCheck = settings.GetHealthCheck();
+            if (customHealthCheck == null)
             {
                 return null;
             }
@@ -165,7 +166,8 @@ namespace ServiceStack.Discovery.Consul
             {
                 Id = "SS-HealthCheck",
                 ServiceId = serviceId,
-                IntervalInSeconds = settings.GetHealthCheck().IntervalInSeconds,
+                IntervalInSeconds = customHealthCheck.IntervalInSeconds,
+                DeregisterCriticalServiceAfterInSeconds = customHealthCheck.DeregisterIfCriticalAfterInMinutes,
                 Http = baseUrl.CombineWith("/json/reply/healthcheck"),
                 Notes = "This check is an HTTP GET request which expects the service to return 200 OK"
             };
@@ -216,7 +218,8 @@ namespace ServiceStack.Discovery.Consul
                 ServiceId = serviceId,
                 IntervalInSeconds = 30,
                 Http = baseUrl.CombineWith("/json/reply/heartbeat"),
-                Notes = "A heartbeat service to check if the service is reachable, expects 200 response"
+                Notes = "A heartbeat service to check if the service is reachable, expects 200 response",
+                DeregisterCriticalServiceAfterInSeconds = 90
             };
         }
     }

--- a/src/Servicestack.Discovery.Consul/Dtos/ServiceRegistration.cs
+++ b/src/Servicestack.Discovery.Consul/Dtos/ServiceRegistration.cs
@@ -23,6 +23,6 @@ namespace ServiceStack.Discovery.Consul
         public string Http { get; set; }
         public string Tcp { get; set; }
         public string Notes { get; set; }
-        public int? DeregisterCriticalServiceAfterInSeconds { get; set; }
+        public int? DeregisterCriticalServiceAfterInMinutes { get; set; }
     }
 }

--- a/src/Servicestack.Discovery.Consul/Dtos/ServiceRegistration.cs
+++ b/src/Servicestack.Discovery.Consul/Dtos/ServiceRegistration.cs
@@ -23,5 +23,6 @@ namespace ServiceStack.Discovery.Consul
         public string Http { get; set; }
         public string Tcp { get; set; }
         public string Notes { get; set; }
+        public int? DeregisterCriticalServiceAfterInSeconds { get; set; }
     }
 }

--- a/src/Servicestack.Discovery.Consul/HostHealthCheck.cs
+++ b/src/Servicestack.Discovery.Consul/HostHealthCheck.cs
@@ -10,12 +10,14 @@ namespace ServiceStack.Discovery.Consul
         /// </summary>
         /// <param name="healthCheckDelegate"></param>
         /// <param name="intervalInSeconds"></param>
-        public HostHealthCheck(HealthCheckDelegate healthCheckDelegate, int intervalInSeconds = 60)
+        /// <param name="deregisterIfCriticalAfterInMinutes"></param>
+        public HostHealthCheck(HealthCheckDelegate healthCheckDelegate, int intervalInSeconds = 60, int? deregisterIfCriticalAfterInMinutes = null)
         {
             healthCheckDelegate.ThrowIfNull(nameof(healthCheckDelegate));
             
             HealthCheckDelegate = healthCheckDelegate;
             IntervalInSeconds = intervalInSeconds;
+            DeregisterIfCriticalAfterInMinutes = deregisterIfCriticalAfterInMinutes;
         }
 
         /// <summary>
@@ -27,5 +29,10 @@ namespace ServiceStack.Discovery.Consul
         /// How often the check is run, defaults to 60 seconds
         /// </summary>
         public int IntervalInSeconds { get; set; }
+
+        /// <summary>
+        /// If health check is failing after x minutes, will deregister service, leave as default(null) to disable
+        /// </summary>
+        public int? DeregisterIfCriticalAfterInMinutes { get; set; }
     }
 }

--- a/src/Servicestack.Discovery.Consul/Validators/ConsulRegisterCheckValidator.cs
+++ b/src/Servicestack.Discovery.Consul/Validators/ConsulRegisterCheckValidator.cs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 namespace ServiceStack.Discovery.Consul
 {
+    using System;
     using ServiceStack.FluentValidation;
 
     public class ConsulRegisterCheckValidator : AbstractValidator<ConsulRegisterCheck>
@@ -16,7 +17,10 @@ namespace ServiceStack.Discovery.Consul
                 .NotEmpty()
                 .WithName("Method")
                 .WithMessage("One of Http, Script or Tcp must be defined")
-                .Unless(x => !x.Script.IsNullOrEmpty() || !x.TCP.IsNullOrEmpty());
+                .Unless(x => !x.Script.IsNullOrEmpty() || !x.TCP.IsNullOrEmpty())
+                .Must(x => Uri.IsWellFormedUriString(x, UriKind.Absolute))
+                .WithName("InvalidUrl")
+                .WithMessage("The http check is not a valid absolute url");
 
             // if script, http or tcp is set, interval is required
             RuleFor(x => x.IntervalInSeconds)
@@ -25,6 +29,10 @@ namespace ServiceStack.Discovery.Consul
                 .When(
                     x =>
                     !x.HTTP.IsNullOrEmpty() || !x.TCP.IsNullOrEmpty() || !x.Script.IsNullOrEmpty());
+
+            // if specified, must be positive value
+            RuleFor(x => x.DeregisterCriticalServiceAfterInMinutes)
+                .GreaterThan(0).When(x => x.DeregisterCriticalServiceAfterInMinutes.HasValue);
 
             // If docker container id is provided, script is evaluated using the specified shell
             RuleFor(x => x.Shell).NotEmpty().When(x => !x.DockerContainerID.IsNullOrEmpty());

--- a/test/ServiceStack.Discovery.Consul.Tests/ConsulFeatureSettingsTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/ConsulFeatureSettingsTests.cs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/. 
 
-using System;
 using FluentAssertions;
 using Xunit;
 
@@ -77,7 +76,7 @@ namespace ServiceStack.Discovery.Consul.Tests
         [Fact]
         public void CanAddServiceChecks()
         {
-            settings.AddServiceCheck(new ConsulRegisterCheck("checkone", "id1") { HTTP = "test", IntervalInSeconds = 10 });
+            settings.AddServiceCheck(new ConsulRegisterCheck("checkone", "id1") { HTTP = "http://test", IntervalInSeconds = 10 });
 
             var check = settings.GetServiceChecks().Should().ContainSingle().Subject;
             check.Name.Should().Be("checkone");

--- a/test/ServiceStack.Discovery.Consul.Tests/ConsulRegisterCheckTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/ConsulRegisterCheckTests.cs
@@ -4,7 +4,7 @@
 namespace ServiceStack.Discovery.Consul.Tests
 {
     using FluentAssertions;
-
+    using ServiceStack.FluentValidation;
     using ServiceStack.FluentValidation.TestHelper;
 
     using Xunit;
@@ -16,6 +16,18 @@ namespace ServiceStack.Discovery.Consul.Tests
         public ConsulRegisterCheckTests()
         {
             validator = new ConsulRegisterCheckValidator();
+        }
+
+        [Fact]
+        public void NoValidation_IsThrown_ForMinRequired()
+        {
+            validator.ValidateAndThrow(new ConsulRegisterCheck("name") {HTTP = "http://test", IntervalInSeconds = 1});
+        }
+
+        [Fact]
+        public void Http_MustBe_ValidUrl()
+        {
+            validator.ShouldHaveValidationErrorFor(x => x.HTTP, new ConsulRegisterCheck("a") {HTTP = "t", IntervalInSeconds = 1});
         }
 
         [Theory]
@@ -56,13 +68,24 @@ namespace ServiceStack.Discovery.Consul.Tests
         [InlineData(-1)]
         public void Interval_Must_Be_Greater_Than_Zero_If_Specified(int seconds)
         {
-            validator.ShouldHaveValidationErrorFor(x => x.IntervalInSeconds, new ConsulRegisterCheck("a") { Script = "a", IntervalInSeconds = seconds });
+            validator.ShouldHaveValidationErrorFor(x => x.IntervalInSeconds,
+                new ConsulRegisterCheck("a") { Script = "a", IntervalInSeconds = seconds });
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void DeregisterCriticalServiceAfterInMinutes_Must_Be_Greater_Than_Zero_If_Specified(int minutes)
+        {
+            validator.ShouldHaveValidationErrorFor(x => x.DeregisterCriticalServiceAfterInMinutes,
+                new ConsulRegisterCheck("a") { DeregisterCriticalServiceAfterInMinutes = minutes });
         }
 
         [Fact]
         public void Shell_Is_Required_If_DockerContainerId_Is_Specified()
         {
-            validator.ShouldHaveValidationErrorFor(x => x.Shell, new ConsulRegisterCheck("a") { DockerContainerID = "a" });
+            validator.ShouldHaveValidationErrorFor(x => x.Shell,
+                new ConsulRegisterCheck("a") { DockerContainerID = "a" });
         }
 
         [Theory]

--- a/test/ServiceStack.Discovery.Consul.Tests/ConsulServiceRegistrationTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/ConsulServiceRegistrationTests.cs
@@ -3,13 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 namespace ServiceStack.Discovery.Consul.Tests
 {
-    using System.Linq;
-
     using FluentAssertions;
 
     using ServiceStack.FluentValidation.TestHelper;
-    using ServiceStack.Text;
-
     using Xunit;
 
     public class ConsulServiceRegistrationTests

--- a/test/ServiceStack.Discovery.Consul.Tests/GatewayServiceDiscoveryExceptionpeResolverTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/GatewayServiceDiscoveryExceptionpeResolverTests.cs
@@ -7,11 +7,11 @@ using Xunit;
 namespace ServiceStack.Discovery.Consul.Tests
 {
     [Collection("AppHost")]
-    public class GatewayServiceDiscoveryExceptionpeResolverTests
+    public class GatewayServiceDiscoveryExceptionResolverTests
     {
         private readonly AppHostFixture fixture;
 
-        public GatewayServiceDiscoveryExceptionpeResolverTests(AppHostFixture fixture)
+        public GatewayServiceDiscoveryExceptionResolverTests(AppHostFixture fixture)
         {
             this.fixture = fixture;
         }

--- a/test/ServiceStack.Discovery.Consul.Tests/HostHealthCheckTests.cs
+++ b/test/ServiceStack.Discovery.Consul.Tests/HostHealthCheckTests.cs
@@ -45,5 +45,14 @@ namespace ServiceStack.Discovery.Consul.Tests
 
             check.IntervalInSeconds.Should().Be(23);
         }
+
+        [Fact]
+        public void CanAssignDeregister()
+        {
+            var healthCheck = new HealthCheck(ServiceHealth.Ok, "ok");
+            var check = new HostHealthCheck(host => healthCheck,deregisterIfCriticalAfterInMinutes: 23);
+
+            check.DeregisterIfCriticalAfterInMinutes.Should().Be(23);
+        }
     }
 }


### PR DESCRIPTION
Default heartbeat will now deregister service if critical for 90 minutes.
Can set deregister timeout in custom health checks - disabled by default
